### PR TITLE
Only remove the server prefix if the path starts with it

### DIFF
--- a/scenarios/har/1/openapi.yaml
+++ b/scenarios/har/1/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 servers:
-  - url: /v3
+  - url: /api/v3
 info:
   description: |-
     This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about

--- a/scenarios/simple/6/http.json
+++ b/scenarios/simple/6/http.json
@@ -1,0 +1,17 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "/ping"
+    },
+    "response": {
+      "status": 200,
+      "content": {
+        "mimeType": "text/plain",
+        "parsed": {
+          "oneEntry": 1
+        }
+      }
+    }
+  }
+]

--- a/scenarios/simple/6/openapi.yaml
+++ b/scenarios/simple/6/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Minimal example
+  version: 0.1.0
+servers:
+  - url: "http://localhost:8000"
+paths:
+  /ping:
+    get:
+      responses:
+        '200':
+          description: Returns `pong`
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: pong

--- a/src/rule/index.test.ts
+++ b/src/rule/index.test.ts
@@ -161,6 +161,33 @@ describe("Test Rule Scenarios", () => {
         },
       },
     ],
+    [
+      "6",
+      {
+        success: true,
+        apiSubtree: {
+          "/ping": {
+            x_name: "/ping",
+            x_x_x_x_results: {
+              hits: 0,
+            },
+            get: {
+              responses: {
+                "200": {
+                  x_x_x_x_results: {
+                    hits: 0,
+                  },
+                },
+              },
+              x_x_x_x_name: "get",
+              x_x_x_x_results: {
+                hits: 0,
+              },
+            },
+          },
+        },
+      },
+    ],
   ];
 
   const scenarios = scenarioNames.map((s) => {

--- a/src/rule/index.ts
+++ b/src/rule/index.ts
@@ -200,25 +200,14 @@ export const match = (api: a.Root, input: har.t): Result.Result => {
   if (!result.success) {
     return result
   }
-
-  const pathWithNoServer = removeServer(api, input.request.path);
-  const foundPath = findPath(api, pathWithNoServer)
-
-  if (foundPath !== null) {
-    const path = foundPath.x_name
-    const operationToMatch = input.request.method;
-    result = matchResponse(
-      api.paths[path][operationToMatch],
-      input.response,
-      result,
-      path
-    );
-  } else {
-    // TODO: This shouldn't happen since we have already called findPath in
-    // matchRequest and it was successful
-    console.error("Could not find the normalized path for ", pathWithNoServer);
-    return result;
-  }
+  const pathNode = matchPath(api, input.request) as a.Path;
+  const operationToMatch = input.request.method;
+  result = matchResponse(
+    pathNode[operationToMatch],
+    input.response,
+    result,
+    pathNode.x_name
+  );
 
   return result;
 };


### PR DESCRIPTION
Also updated the server url for scenario 1 so that it finds the paths correctly. Is this how we want to use servers.url in the openapi specs?