### PR TITLE
Support multiple HAR files as input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,23 +31,22 @@ parser.add_argument("apispec", {
   nargs: 1,
 });
 
-parser.add_argument("recording", {
-  help: "Path to a har file or simple format if simple flag was passed",
-  nargs: 1,
+parser.add_argument("recordings", {
+  help: "Path to a har file or simple format if simple flag was passed. Can be used multiple times.",
+  nargs: '+',
 });
 
 const args: {
   simple: boolean;
   apispec: string;
-  recording: string;
+  recordings: string[];
   verbose: boolean;
   coverage: boolean;
 } = parser.parse_args();
 
 if (args.simple) {
   const openApiPath = args.apispec[0];
-  const harPath = args.recording[0];
-  runWithSimple(openApiPath, harPath).then(({ api, results }) => {
+  runWithSimple(openApiPath, args.recordings).then(({ api, results }) => {
     if (args.coverage) {
       printReport(api);
     }
@@ -69,8 +68,7 @@ if (args.simple) {
   });
 } else {
   const openApiPath = args.apispec[0];
-  const harPath = args.recording[0];
-  run(openApiPath, harPath).then(({ api, results }) => {
+  run(openApiPath, args.recordings).then(({ api, results }) => {
     if (args.coverage) {
       printReport(api);
     }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -7,13 +7,13 @@ import { Result } from "../rule/model";
 
 export const runWithSimple = async (
   openApiPath: string,
-  requestResponsePath: string
+  requestResponsePaths: string[]
 ): Promise<{
   api: a.Root;
   results: Result[];
 }> => {
   const api = await getApi(openApiPath);
-  const reqRes = await getSimple(requestResponsePath);
+  const reqRes = (await Promise.all(requestResponsePaths.map(getSimple))).flat();
 
   const results = [];
 
@@ -30,13 +30,13 @@ export const runWithSimple = async (
 
 export const run = async (
   openApiPath: string,
-  requestResponsePath: string
+  requestResponsePaths: string[]
 ): Promise<{
   api: a.Root;
   results: Result[];
 }> => {
   const api = await getApi(openApiPath);
-  const reqRes = await getParsedHar(requestResponsePath);
+  const reqRes = (await Promise.all(requestResponsePaths.map(getParsedHar))).flat();
 
   const results = [];
   for (const r of reqRes) {


### PR DESCRIPTION
When your HAR data is generated by a test suite, you will probably end up with multiple HAR files because you do not want to coordinate the HAR generation across e.g. test files. This update makes the arg parser assume all positional arguments after the first are HAR files. With this update you can
```
apidelta openapi-hemprojects.json *.har
```