### PR TITLE
Locate the pathnode "properly" when matching the response object

### DIFF
--- a/src/rule/index.ts
+++ b/src/rule/index.ts
@@ -200,25 +200,14 @@ export const match = (api: a.Root, input: har.t): Result.Result => {
   if (!result.success) {
     return result
   }
-
-  const pathWithNoServer = removeServer(api, input.request.path);
-  const foundPath = findPath(api, pathWithNoServer)
-
-  if (foundPath !== null) {
-    const path = foundPath.x_name
-    const operationToMatch = input.request.method;
-    result = matchResponse(
-      api.paths[path][operationToMatch],
-      input.response,
-      result,
-      path
-    );
-  } else {
-    // TODO: This shouldn't happen since we have already called findPath in
-    // matchRequest and it was successful
-    console.error("Could not find the normalized path for ", pathWithNoServer);
-    return result;
-  }
+  const pathNode = matchPath(api, input.request) as a.Path;
+  const operationToMatch = input.request.method;
+  result = matchResponse(
+    pathNode[operationToMatch],
+    input.response,
+    result,
+    pathNode.x_name
+  );
 
   return result;
 };


### PR DESCRIPTION
When dropping simple support, I rewrote the various scenario tests to use HAR data. I then discovered that we failed on paths with patterns in them. I think that the approach in this PR sort of works, but the approach in this PR is somewhat better because it uses the same approach that is used in `makeRequest`. Probably, we should refactor this so that lookup, request matching and response validation are separate things.