### PR TITLE
add --match-server-url flag to improve openapi server url matching

### DIFF
--- a/src/httpParsing/model.ts
+++ b/src/httpParsing/model.ts
@@ -12,6 +12,7 @@ export type response = {
 
 export type request = {
   method: "post" | "get" | "put" | "patch" | "delete";
+  url: URL;
   path: string;
   queryString?: [
     {

--- a/src/httpParsing/parseHar.test.ts
+++ b/src/httpParsing/parseHar.test.ts
@@ -15,6 +15,7 @@ const expected: har.t = {
   },
   request: {
     method: "post",
+    url: new URL("https://petstore3.swagger.io/api/v3/pet/12/uploadImage"),
     path: "/api/v3/pet/12/uploadImage",
     postData: undefined,
   },

--- a/src/httpParsing/parseHar.ts
+++ b/src/httpParsing/parseHar.ts
@@ -1,7 +1,4 @@
-import { rejects } from "assert";
-import fs from "fs";
-import path from "path";
-import { readFile, readFileasJson } from "../utils/readFile";
+import { readFileasJson } from "../utils/readFile";
 import * as har from "./model";
 
 const getEntries = (harFile: Record<string, any>) => {
@@ -32,6 +29,7 @@ const parseOneHar = (entry: Record<string, any>): har.t => {
     },
     request: {
       method: request.method.toLowerCase(),
+      url: new URL(request.url),
       path: new URL(request.url).pathname,
       postData: request.postData,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,12 @@ parser.add_argument("-c", "--coverage", {
   action: "store_true",
 });
 
+parser.add_argument("-m", "--match-server-url", {
+  default: "none",
+  choices: ["none", "full"],
+  help: "none ignores everything until path, full means entire url has to match",
+});
+
 parser.add_argument("apispec", {
   help: "Path to a open api 3 yaml file",
   nargs: 1,
@@ -35,27 +41,30 @@ const args: {
   recordings: string[];
   verbose: boolean;
   coverage: boolean;
+  match_server_url: "none" | "full";
 } = parser.parse_args();
 
 const openApiPath = args.apispec[0];
-run(openApiPath, args.recordings).then(({ api, results }) => {
-  if (args.coverage) {
-    printReport(api);
-  }
+run(openApiPath, args.recordings, args.match_server_url).then(
+  ({ api, results }) => {
+    if (args.coverage) {
+      printReport(api);
+    }
 
-  if (args.verbose) {
-    results.map(printResult);
-  }
+    if (args.verbose) {
+      results.map(printResult);
+    }
 
-  const errors = results
-    .filter((r) => !r.success)
-    .map((r, i) => {
-      if (i === 0) {
-        console.error("Errors:");
-      }
-      console.error(flattenToLine(r));
-    });
-  if (errors.length > 0) {
-    process.exit(1);
+    const errors = results
+      .filter((r) => !r.success)
+      .map((r, i) => {
+        if (i === 0) {
+          console.error("Errors:");
+        }
+        console.error(flattenToLine(r));
+      });
+    if (errors.length > 0) {
+      process.exit(1);
+    }
   }
-});
+);

--- a/src/rule/findPath.test.ts
+++ b/src/rule/findPath.test.ts
@@ -1,4 +1,4 @@
-import { findPath } from ".";
+import { findPathNodeFromPath } from ".";
 import * as a from "../api/model";
 
 describe("Match paths to path nodes", () => {
@@ -7,7 +7,7 @@ describe("Match paths to path nodes", () => {
     const path = "/should/match/exactly";
     root.paths[path] = a.newPathNode(path);
 
-    const pathNode = findPath(root, path);
+    const pathNode = findPathNodeFromPath(root, path);
 
     expect(pathNode?.x_name).toBe(path);
   });
@@ -17,7 +17,7 @@ describe("Match paths to path nodes", () => {
     const path = "/exact/path";
     root.paths[path] = a.newPathNode(path);
 
-    const pathNode = findPath(root, "should/not/exist");
+    const pathNode = findPathNodeFromPath(root, "should/not/exist");
 
     expect(pathNode).toBe(null);
   });
@@ -27,7 +27,7 @@ describe("Match paths to path nodes", () => {
     const path = "/user/{user_id}";
     root.paths[path] = a.newPathNode(path);
 
-    const pathNode = findPath(root, "/user/1");
+    const pathNode = findPathNodeFromPath(root, "/user/1");
 
     expect(pathNode?.x_name).toBe(path);
   });
@@ -37,7 +37,7 @@ describe("Match paths to path nodes", () => {
     const path = "/user/{user_id}/subresource/{some_id}";
     root.paths[path] = a.newPathNode(path);
 
-    const pathNode = findPath(root, "/user/1/subresource/10");
+    const pathNode = findPathNodeFromPath(root, "/user/1/subresource/10");
 
     expect(pathNode?.x_name).toBe(path);
   });
@@ -50,7 +50,7 @@ describe("Match paths to path nodes", () => {
     const path2 = "/user/{user_id}/subresource/{some_id}/longer";
     root.paths[path2] = a.newPathNode(path2);
 
-    const pathNode = findPath(root, "/user/1/subresource/10");
+    const pathNode = findPathNodeFromPath(root, "/user/1/subresource/10");
 
     expect(pathNode?.x_name).toBe(path1);
   });
@@ -61,7 +61,7 @@ describe("Match paths to path nodes", () => {
     const path2 = "/user/{user_id}/subresource/{some_id}/longer";
     root.paths[path2] = a.newPathNode(path2);
 
-    const pathNode = findPath(root, "/user/1/subresource/10");
+    const pathNode = findPathNodeFromPath(root, "/user/1/subresource/10");
 
     expect(pathNode).toBe(null);
   });
@@ -77,7 +77,10 @@ describe("Match paths to path nodes", () => {
     const path3 = "/user/{user_id}/subresource/{some_id}/subsubresource";
     root.paths[path3] = a.newPathNode(path3);
 
-    const pathNode = findPath(root, "/user/1/subresource/10/subsubresource");
+    const pathNode = findPathNodeFromPath(
+      root,
+      "/user/1/subresource/10/subsubresource"
+    );
 
     expect(pathNode?.x_name).toBe(path3);
   });

--- a/src/rule/index.test.ts
+++ b/src/rule/index.test.ts
@@ -1,10 +1,7 @@
 import path from "path";
 import { match } from ".";
 import getApi from "../api";
-import * as a from "../api/model";
 import { getParsedHar } from "../httpParsing/parseHar";
-import { verbosePrint, yamlDump } from "../utils/print";
-import { Result } from "./model";
 
 describe("Test Simple Scenarios", () => {
   const scenarioNames = [
@@ -185,7 +182,7 @@ describe("Test Simple Scenarios", () => {
 
     const api = await getApi(apiPath);
     const parsedHar = await getParsedHar(httpPath);
-    const result = match(api, parsedHar[0]); // TODO We only test first for now
+    const result = match(api, parsedHar[0], "none"); // TODO We only test first for now
     expect(result).toEqual(expected);
   });
 });
@@ -229,7 +226,7 @@ describe("Test HAR Scenarios", () => {
 
     const api = await getApi(apiPath);
     const parsedHar = await getParsedHar(httpPath);
-    const result = match(api, parsedHar[0]); // TODO We only test first for now
+    const result = match(api, parsedHar[0], "none"); // TODO We only test first for now
     expect(result).toEqual(expected);
   });
 });

--- a/src/rule/serverUrlMatch.test.ts
+++ b/src/rule/serverUrlMatch.test.ts
@@ -1,0 +1,101 @@
+import { removeServer } from ".";
+import * as a from "../api/model";
+
+describe("Truncate server from url", () => {
+  describe("Url is absolute with no path", () => {
+    const root = a.newRootNode();
+    root.servers = [{ url: "http://example.com" }];
+    it("Ignores server and returns path if match-server-url is none", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "none");
+      expect(path).toBe("/test/path");
+    });
+    it("returns null if match-server-url is full", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe(null);
+    });
+    it("returns path if match-server-url is full and paths match", () => {
+      const request = new URL("http://example.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe("/test/path");
+    });
+  });
+
+  describe("Url is absolute with no path, but trailing slash on server", () => {
+    const root = a.newRootNode();
+    root.servers = [{ url: "http://example.com/" }];
+    it("Ignores server and returns path if match-server-url is none", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "none");
+      expect(path).toBe("/test/path");
+    });
+    it("returns null if match-server-url is full", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe(null);
+    });
+    it("returns path if match-server-url is full and paths match", () => {
+      const request = new URL("http://example.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe("/test/path");
+    });
+  });
+
+  describe("Url is absolute with path", () => {
+    const root = a.newRootNode();
+    root.servers = [{ url: "http://example.com/test" }];
+    it("Ignores server and returns path if match-server-url is none", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "none");
+      expect(path).toBe("/path");
+    });
+
+    it("Returns null if match-server-url is full and server does not match", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe(null);
+    });
+
+    it("Returns path if match-server-url is full and server does match", () => {
+      const request = new URL("http://example.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe("/path");
+    });
+
+    describe("Url is absolute with trailing subpath", () => {
+      it("matches localhost path with parameter", () => {
+        const url = "https://sub.example-dev.local:8001/api/v2/";
+        const root = a.newRootNode();
+        root.servers = [{ url: url }];
+        const request = new URL(
+          "http://localhost:34643/api/v2/device/00000000-0000-0000-0000-000000000000"
+        );
+        const path = removeServer(root, request, "none");
+        expect(path).toBe("/device/00000000-0000-0000-0000-000000000000");
+      });
+    });
+  });
+
+  describe("Url is a relative path", () => {
+    const root = a.newRootNode();
+    root.servers = [{ url: "/test" }];
+    it("Ignores server and returns path if match-server-url is none", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "none");
+      expect(path).toBe("/path");
+    });
+
+    it("Return subpath if paths match and match-server-url is full", () => {
+      const request = new URL("http://someOtherServer.com/test/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe("/path");
+    });
+
+    it("Return null if paths do not match and match-server-url is full", () => {
+      const request = new URL("http://someOtherServer.com/nosubpath/path");
+      const path = removeServer(root, request, "full");
+      expect(path).toBe(null);
+    });
+  });
+});

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -7,17 +7,20 @@ import { Result } from "../rule/model";
 
 export const run = async (
   openApiPath: string,
-  requestResponsePaths: string[]
+  requestResponsePaths: string[],
+  match_server_url: string
 ): Promise<{
   api: a.Root;
   results: Result[];
 }> => {
   const api = await getApi(openApiPath);
-  const reqRes = (await Promise.all(requestResponsePaths.map(getParsedHar))).flat();
+  const reqRes = (
+    await Promise.all(requestResponsePaths.map(getParsedHar))
+  ).flat();
 
   const results = [];
   for (const r of reqRes) {
-    const result = match(api, r);
+    const result = match(api, r, match_server_url);
     results.push(result);
   }
 


### PR DESCRIPTION
It will probably be useful to have the full URL in the HAR type. It's
defined as Node's builtin URL class. We will se if this bites us in the
future!