### PR TITLE
Fix path matching bug

### DIFF
--- a/src/rule/findPath.test.ts
+++ b/src/rule/findPath.test.ts
@@ -84,4 +84,17 @@ describe("Match paths to path nodes", () => {
 
     expect(pathNode?.x_name).toBe(path3);
   });
+
+  it("matches on /device/{some_id}/connection when there exists /device/{some_id}/{some_id}", () => {
+    const root: a.Root = a.newRootNode();
+    const path2 = "/device/{some_id}/{some_id}";
+    root.paths[path2] = a.newPathNode(path2);
+
+    const path1 = "/device/{some_id}/connection";
+    root.paths[path1] = a.newPathNode(path1);
+
+    const pathNode = findPathNodeFromPath(root, "/device/10/connection");
+
+    expect(pathNode?.x_name).toBe(path1);
+  });
 });

--- a/src/rule/index.ts
+++ b/src/rule/index.ts
@@ -25,6 +25,9 @@ export const findPathNodeFromPath = (
     .map((p) => p.split("/"))
     .filter((p) => p.length === pathToPatternMatch.length);
 
+  // Pretty stupid to sort, but this solves some cases... and makes the matching more consistent until we rewrite this
+  pathItems.sort();
+
   const foundPath: string[] = [];
   let currentIndex = 0;
   pathItems.map((onePath) => {


### PR DESCRIPTION
Path items are now sorted before they are traversed in the findPathNode
function. The bug was that it matched too eagerly on /{user_id}/{user_id}
when it should have matched /{user_id}/connection.

Sorting is not optimal, but it covers this case with no regressions.